### PR TITLE
remove constructor param for farmingToken

### DIFF
--- a/contracts/KSElasticLMV2.sol
+++ b/contracts/KSElasticLMV2.sol
@@ -132,10 +132,7 @@ contract KSElasticLMV2 is IKSElasticLMV2, KSAdmin, ReentrancyGuard {
     //deploy farmingToken if needed
     address destination;
     if (isUsingToken) {
-      bytes memory creationCode = abi.encodePacked(
-        farmingTokenCreationCode,
-        abi.encode(msg.sender)
-      );
+      bytes memory creationCode = farmingTokenCreationCode;
       bytes32 salt = keccak256(abi.encode(msg.sender, fId));
       assembly {
         destination := create2(0, add(creationCode, 32), mload(creationCode), salt)
@@ -143,7 +140,13 @@ contract KSElasticLMV2 is IKSElasticLMV2, KSAdmin, ReentrancyGuard {
           revert(0, 0)
         }
       }
+
       farm.farmingToken = destination;
+
+      //grant admin to msg.sender
+      IKyberSwapFarmingToken farmingToken = IKyberSwapFarmingToken(destination);
+
+      farmingToken.grantRole(farmingToken.DEFAULT_ADMIN_ROLE(), msg.sender);
     }
 
     //last touched time would be startTime

--- a/contracts/interfaces/periphery/IKyberSwapFarmingToken.sol
+++ b/contracts/interfaces/periphery/IKyberSwapFarmingToken.sol
@@ -81,4 +81,6 @@ interface IKyberSwapFarmingToken is IAccessControl {
   function addWhitelist(address account) external;
 
   function removeWhitelist(address account) external;
+
+  function DEFAULT_ADMIN_ROLE() external view returns (bytes32);
 }

--- a/contracts/periphery/KyberSwapFarmingToken.sol
+++ b/contracts/periphery/KyberSwapFarmingToken.sol
@@ -15,10 +15,8 @@ contract KyberSwapFarmingToken is ERC20, ERC20Burnable, ERC20Permit, AccessContr
 
   mapping(address => bool) public isWhitelist;
 
-  constructor(
-    address owner
-  ) ERC20('KyberSwapFarmingToken', 'KS-FT') ERC20Permit('KyberSwapFarmingToken') {
-    _setupRole(DEFAULT_ADMIN_ROLE, owner);
+  constructor() ERC20('KyberSwapFarmingToken', 'KS-FT') ERC20Permit('KyberSwapFarmingToken') {
+    _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
     _setupRole(OPERATOR_ROLE, msg.sender);
   }
 

--- a/test/helpers/FoundryHelper.sol
+++ b/test/helpers/FoundryHelper.sol
@@ -37,7 +37,8 @@ abstract contract FoundryHelper is Test {
     (user4, privUser4) = makeAddrAndKey('user4');
   }
 
-  function _signMessage(bytes32 message, uint256 _key) internal returns (bytes memory) {
+  //restricted to pure to avoid noisy warnings
+  function _signMessage(bytes32 message, uint256 _key) internal pure returns (bytes memory) {
     (uint8 v, bytes32 r, bytes32 s) = vm.sign(_key, keccak256(abi.encodePacked(message)));
     return abi.encodePacked(r, s, v);
   }


### PR DESCRIPTION
remove constructor param for farmingToken so it can be verify automatically
we will grant msg.sender admin role later in addFarm logics